### PR TITLE
dashcam2josm: Fix relative paths

### DIFF
--- a/dashcam2josm_v3.py
+++ b/dashcam2josm_v3.py
@@ -397,7 +397,7 @@ def main():
     namesRear = []
     for in_file in in_files:
         fileNum = fileNum + 1
-        name = in_file[0:len(in_file)-4]
+        name = os.path.splitext(os.path.basename(in_file))[0]
         if name.upper().endswith("R"):
             namesRear.append(name)
         else:


### PR DESCRIPTION
Running `python dashcam2josm_v3.py -i ../*.MP4` would delete the source videos due to the `..` characters being maintained in the name and exiting out of the destination directory when cleaning up.